### PR TITLE
Add github.com to ssh known hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN set -ex \
     && go install github.com/go-delve/delve/cmd/dlv@latest \
     && go install github.com/cosmtrek/air@latest \
     && wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O /usr/local/bin/wait-for-it \
-    && chmod u+x /usr/local/bin/wait-for-it
+    && chmod u+x /usr/local/bin/wait-for-it \
+    && mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
Private repoをgit cloneできるようにssh known hostsにgithub.comを追加